### PR TITLE
fix: streamline exposed fields in constructor type

### DIFF
--- a/src/layer.ts
+++ b/src/layer.ts
@@ -1,7 +1,7 @@
 import earcut from 'earcut';
 import mapboxgl, { CustomLayerInterface } from 'mapbox-gl';
 
-type HeatmapLayer = {
+type MapboxInterpolateHeatmapLayerOptions = {
   id: string;
   data: { lat: number; lon: number; val: number }[];
   framebufferFactor?: number;
@@ -13,10 +13,9 @@ type HeatmapLayer = {
   valueToColor?: string;
   valueToColor4?: string;
   textureCoverSameAreaAsROI?: boolean;
-  points?: number[][];
-} & CustomLayerInterface;
+};
 
-class MapboxInterpolateHeatmapLayer implements HeatmapLayer {
+class MapboxInterpolateHeatmapLayer implements CustomLayerInterface {
   id = '';
   data: { lat: number; lon: number; val: number }[] = [];
   framebufferFactor = 0.3;
@@ -56,7 +55,7 @@ class MapboxInterpolateHeatmapLayer implements HeatmapLayer {
   uUi: WebGLUniformLocation | null = null;
   uXi: WebGLUniformLocation | null = null;
 
-  constructor(options: HeatmapLayer) {
+  constructor(options: MapboxInterpolateHeatmapLayerOptions) {
     this.id = options.id || '';
     this.data = options.data || [];
     this.aoi = options.aoi || [];

--- a/src/layer.ts
+++ b/src/layer.ts
@@ -16,14 +16,14 @@ type MapboxInterpolateHeatmapLayerOptions = {
 };
 
 class MapboxInterpolateHeatmapLayer implements CustomLayerInterface {
-  id = '';
-  data: { lat: number; lon: number; val: number }[] = [];
-  framebufferFactor = 0.3;
-  maxValue = -Infinity;
-  minValue = Infinity;
-  opacity = 0.5;
-  p = 3;
-  aoi?: { lat: number; lon: number }[] = [];
+  id: string;
+  data: { lat: number; lon: number; val: number }[];
+  framebufferFactor: number;
+  maxValue: number;
+  minValue: number;
+  opacity: number;
+  p: number;
+  aoi?: { lat: number; lon: number }[];
   valueToColor?: string;
   valueToColor4?: string;
   textureCoverSameAreaAsROI: boolean;


### PR DESCRIPTION
Currently, the `HeatmapLayer` type is exposed for package consumers as the type definition for the layer's `constructor`:
https://github.com/vinayakkulkarni/mapbox-gl-interpolate-heatmap/blob/957e4cc77cdb7e4857279cf61eb3eb214670c5af/src/layer.ts#L4-L17

However, including `CustomLayerInterface` in this type results in internal fields such as `type` and `render` being included + required in this type:

```
error TS2345: Argument of type '{ id: string; data: { lat: number; lon: number; val: number; }[]; }' is not assignable to parameter of type 'HeatmapLayer'.
  Type '{ id: string; data: { lat: number; lon: number; val: number; }[]; }' is missing the following properties from type 'CustomLayerInterface': type, render

57     const layer = new MapboxInterpolateHeatmapLayer({ id, data });
```

Similarly, fields such as `points` are accepted in this constructor type despite not being used.

To fix this, I've created a separate options object which includes only fields used in the `constructor` implementation. I've also refactored the class a bit to remove duplicated default field values.